### PR TITLE
chore: bump node to 10 and puppeteer to 1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM node:8-slim
+FROM node:10-slim
 
 RUN apt-get update && \
-apt-get install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
-libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
-ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget && \
-wget https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64.deb && \
-dpkg -i dumb-init_*.deb && rm -f dumb-init_*.deb && \
-apt-get clean && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+    apt-get install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+    libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+    libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
+    libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
+    fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
+    ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget && \
+    wget https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64.deb && \
+    dpkg -i dumb-init_*.deb && rm -f dumb-init_*.deb && \
+    apt-get clean && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 
-RUN yarn global add puppeteer@1.8.0 && yarn cache clean
+RUN yarn global add puppeteer@1.10.0 && yarn cache clean
 
 ENV NODE_PATH="/usr/local/share/.config/yarn/global/node_modules:${NODE_PATH}"
 
@@ -28,7 +28,7 @@ WORKDIR /app
 
 # Add user so we don't need --no-sandbox.
 RUN mkdir /screenshots \
-	&& mkdir -p /home/pptruser/Downloads \
+    && mkdir -p /home/pptruser/Downloads \
     && chown -R pptruser:pptruser /home/pptruser \
     && chown -R pptruser:pptruser /usr/local/share/.config/yarn/global/node_modules \
     && chown -R pptruser:pptruser /screenshots \


### PR DESCRIPTION
I was using this Dockerfile to test in gitlab an image for AppEngine. AppEngine just allowed node 10 and I updated the whole test chain back.