### PR TITLE
Updating node version to the latest LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-slim
+FROM node:12-slim
 
 RUN apt-get update && \
 apt-get install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \


### PR DESCRIPTION
Lighthouse (runs with puppeter) requires at least node 10.13

Closes #39 